### PR TITLE
Feature/cvsb 6660

### DIFF
--- a/src/assets/enum.ts
+++ b/src/assets/enum.ts
@@ -12,7 +12,8 @@ export enum ERRORS {
 
 export enum ACTIVITY_TYPE {
     TEST = "Test",
-    WAIT_TIME = "Wait Time"
+    WAIT_TIME = "Wait Time",
+    TIME_NOT_TESTING = "Time not Testing"
 }
 
 export enum TIMEZONE {

--- a/src/config/config.yml
+++ b/src/config/config.yml
@@ -10,6 +10,8 @@ invoke:
       testStations:
           name: cvs-svc-test-stations
           mock: tests/resources/test-stations-200-response.json
+      getActivities:
+        name: cvs-svc-activities
   remote:
     params:
       apiVersion: 2015-03-31
@@ -18,6 +20,8 @@ invoke:
           name: test-results-${BRANCH}
       testStations:
           name: test-stations-${BRANCH}
+      getActivities:
+        name: activities-${BRANCH}
 s3:
   local:
     endpoint: http://localhost:7000

--- a/src/config/config.yml
+++ b/src/config/config.yml
@@ -11,7 +11,8 @@ invoke:
           name: cvs-svc-test-stations
           mock: tests/resources/test-stations-200-response.json
       getActivities:
-        name: cvs-svc-activities
+          name: cvs-svc-activities
+          mock: tests/resources/wait-time-response.json
   remote:
     params:
       apiVersion: 2015-03-31
@@ -21,7 +22,7 @@ invoke:
       testStations:
           name: test-stations-${BRANCH}
       getActivities:
-        name: activities-${BRANCH}
+          name: activities-${BRANCH}
 s3:
   local:
     endpoint: http://localhost:7000

--- a/src/models/index.d.ts
+++ b/src/models/index.d.ts
@@ -45,6 +45,28 @@ interface IActivity {
     notes: string;
 }
 
+interface ITestType {
+    testTypeStartTimestamp: string;
+    testTypeName: string;
+    testResult: string;
+    certificateNumber: string;
+    testExpiryDate: number;
+    testTypeEndTimeStamp: string;
+}
+
+interface ITestResults {
+    testerStaffId: string;
+    vrm: string;
+    testStationPNumber: string;
+    preparerId: string;
+    numberOfSeats: number;
+    testStartTimestamp: string;
+    testEndTimestamp: string;
+    testTypes: ITestType;
+    vin: string;
+    vehicleType: string
+}
+
 interface IInvokeConfig {
     params: { apiVersion: string; endpoint?: string; };
     functions: { testResults: { name: string }, testStations: { name: string; mock: string }, getActivities: { name: string } };
@@ -56,4 +78,4 @@ interface IActivitiesList {
     activity: any
 }
 
-export {IS3Config, IActivity, IInvokeConfig, IMOTConfig, IActivitiesList};
+export {IS3Config, IActivity, IInvokeConfig, IMOTConfig, ITestResults, IActivitiesList};

--- a/src/models/index.d.ts
+++ b/src/models/index.d.ts
@@ -50,4 +50,10 @@ interface IInvokeConfig {
     functions: { testResults: { name: string }, testStations: { name: string; mock: string }, getActivities: { name: string } };
 }
 
-export {IS3Config, IActivity, IInvokeConfig, IMOTConfig};
+interface IActivitiesList {
+    startTime: string,
+    activityType: string,
+    activity: any
+}
+
+export {IS3Config, IActivity, IInvokeConfig, IMOTConfig, IActivitiesList};

--- a/src/models/index.d.ts
+++ b/src/models/index.d.ts
@@ -41,11 +41,13 @@ interface IActivity {
     testerStaffId: string;
     startTime: string;
     endTime: string;
+    waitReason: [string];
+    notes: string;
 }
 
 interface IInvokeConfig {
     params: { apiVersion: string; endpoint?: string; };
-    functions: { testResults: { name: string }, testStations: { name: string; mock: string } };
+    functions: { testResults: { name: string }, testStations: { name: string; mock: string }, getActivities: { name: string } };
 }
 
 export {IS3Config, IActivity, IInvokeConfig, IMOTConfig};

--- a/src/services/ActivitiesService.ts
+++ b/src/services/ActivitiesService.ts
@@ -1,0 +1,60 @@
+import {IInvokeConfig} from "../models";
+import {PromiseResult} from "aws-sdk/lib/request";
+import {AWSError, Lambda} from "aws-sdk";
+import {LambdaService} from "./LambdaService";
+import {Configuration} from "../utils/Configuration";
+import moment from "moment";
+import {Service} from "../models/injector/ServiceDecorator";
+
+@Service()
+class ActivitiesService {
+    private readonly lambdaClient: LambdaService;
+    private readonly config: Configuration;
+
+    constructor(lambdaClient: LambdaService) {
+        this.lambdaClient = lambdaClient;
+        this.config = Configuration.getInstance();
+    }
+
+    /**
+     * Retrieves Activities based on the provided parameters
+     * @param params - getActivities query parameters
+     */
+    public getActivities(params: any): Promise<any> {
+        const config: IInvokeConfig = this.config.getInvokeConfig();
+        const invokeParams: any = {
+            FunctionName: config.functions.getActivities.name,
+            InvocationType: "RequestResponse",
+            LogType: "Tail",
+            Payload: JSON.stringify({
+                httpMethod: "GET",
+                path: "/activities/details",
+                queryStringParameters: params
+            }),
+        };
+        return this.lambdaClient.invoke(invokeParams)
+        .then((response: PromiseResult<Lambda.Types.InvocationResponse, AWSError>) => {
+            const payload: any = this.lambdaClient.validateInvocationResponse(response); // Response validation
+            const activityResults: any[] = JSON.parse(payload.body); // Response conversion
+            console.log(`Wait Activities: ${activityResults.length}`);
+
+            // Sort results by startTime
+            activityResults.sort((first: any, second: any): number => {
+                if (moment(first.startTime).isBefore(second.startTime)) {
+                    return -1;
+                }
+
+                if (moment(first.startTime).isAfter(second.startTime)) {
+                    return 1;
+                }
+
+                return 0;
+            });
+
+            return activityResults;
+        });
+    }
+
+}
+
+export { ActivitiesService };

--- a/src/services/ReportGenerationService.ts
+++ b/src/services/ReportGenerationService.ts
@@ -33,17 +33,14 @@ class ReportGenerationService {
         })
         .then((testResults: any) => {
             // Fetch 'wait' activities for this visit activity
-
             return this.activitiesService.getActivities({
                 testerStaffId: activity.testerStaffId,
                 fromStartTime: activity.startTime,
                 toStartTime: activity.endTime,
                 testStationPNumber: activity.testStationPNumber,
                 activityType: "wait",
-            }).then((result: any[]) => {
-                waitActivities = result;
-                console.log(`wait Activities Size: ${result.length}`);
-
+            }).then((waitActivities: any[]) => {
+                console.log(`wait Activities Size: ${waitActivities.length}`);
                 const totalActivitiesLen = testResults.length + waitActivities.length;
                 console.log(`Total Activities Len: ${totalActivitiesLen}`);
                 // Fetch and populate the ATF template
@@ -79,6 +76,7 @@ class ReportGenerationService {
                             detailsTemplate.certificateNumber.value = testType.certificateNumber;
                             detailsTemplate.expiryDate.value = moment(testType.testExpiryDate).tz(TIMEZONE.LONDON).format("DD/MM/YYYY");
                         }
+                        console.log(`Checking for wait activities details.`);
                         // Populate wait activities in the report
                         for (let i = testResults.length, j = 0; i < template.reportTemplate.activityDetails.length && j < waitActivities.length; i++, j++) {
                             console.log(`Populating wait activities details in report`);
@@ -86,8 +84,7 @@ class ReportGenerationService {
                             const waitActivityResult: any = waitActivities[j];
                             let waitReasons: string = "";
                             let additionalNotes: string = "";
-
-
+                            
                             if (waitActivityResult.waitReason) {
                                 waitReasons = `Reason for waiting: ${waitActivityResult.waitReason};\r\n`;
                             }
@@ -99,7 +96,6 @@ class ReportGenerationService {
                             detailsTemplate.startTime.value = moment(waitActivityResult.startTime).tz(TIMEZONE.LONDON).format("HH:mm:ss");
                             detailsTemplate.finishTime.value = moment(waitActivityResult.endTime).tz(TIMEZONE.LONDON).format("HH:mm:ss");
                             detailsTemplate.failureAdvisoryItemsQAIComments.value = waitReasons + additionalNotes;
-
                         }
                         return template.workbook.xlsx.writeBuffer()
                             .then((buffer: Excel.Buffer) => {

--- a/src/services/ReportGenerationService.ts
+++ b/src/services/ReportGenerationService.ts
@@ -44,7 +44,7 @@ class ReportGenerationService {
                 const totalActivitiesLen = testResults.length + waitActivities.length;
                 console.log(`Total Activities Len: ${totalActivitiesLen}`);
                 // Fetch and populate the ATF template
-                return this.fetchATFTemplate(testResults.length)
+                return this.fetchATFTemplate(totalActivitiesLen)
                     .then((template: { workbook: Excel.Workbook, reportTemplate: any }) => {
                         const siteVisitDetails: any = template.reportTemplate.siteVisitDetails;
                         const declaration: any = template.reportTemplate.declaration;
@@ -76,11 +76,9 @@ class ReportGenerationService {
                             detailsTemplate.certificateNumber.value = testType.certificateNumber;
                             detailsTemplate.expiryDate.value = moment(testType.testExpiryDate).tz(TIMEZONE.LONDON).format("DD/MM/YYYY");
                         }
-                        console.log(`Checking for wait activities details.`);
-                        console.log(`Two: wait Activities Size: ${waitActivities.length}`);
-                        console.log(`Two: TestResults Size: ${testResults.length}`);
+
                         // Populate wait activities in the report
-                        for (let i = testResults.length, j = 0; j < waitActivities.length; i++, j++) {
+                        for (let i = testResults.length, j = 0; i < template.reportTemplate.activityDetails.length && j < waitActivities.length; i++, j++) {
                             console.log(`Populating wait activities details in report`);
                             const detailsTemplate: any = template.reportTemplate.activityDetails[i];
                             const waitActivityResult: any = waitActivities[j];

--- a/src/services/ReportGenerationService.ts
+++ b/src/services/ReportGenerationService.ts
@@ -77,7 +77,7 @@ class ReportGenerationService {
                             detailsTemplate.expiryDate.value = moment(testType.testExpiryDate).tz(TIMEZONE.LONDON).format("DD/MM/YYYY");
                         }
 
-                        // Populate wait activities in the report
+                       /* // Populate wait activities in the report
                         for (let i = testResults.length, j = 0; i < template.reportTemplate.activityDetails.length && j < waitActivities.length; i++, j++) {
                             console.log(`Populating wait activities details in report`);
                             const detailsTemplate: any = template.reportTemplate.activityDetails[i];
@@ -95,14 +95,15 @@ class ReportGenerationService {
                             detailsTemplate.activity.value = (waitActivityResult.activityType === "visit") ? ACTIVITY_TYPE.TEST : ACTIVITY_TYPE.WAIT_TIME;
                             detailsTemplate.startTime.value = moment(waitActivityResult.startTime).tz(TIMEZONE.LONDON).format("HH:mm:ss");
                             detailsTemplate.finishTime.value = moment(waitActivityResult.endTime).tz(TIMEZONE.LONDON).format("HH:mm:ss");
-                        }
+                        }*/
                         return template.workbook.xlsx.writeBuffer()
                             .then((buffer: Excel.Buffer) => {
                                 return {
                                     // tslint:disable-next-line
                                     fileName: `ATFReport_${moment(activity.startTime).tz(TIMEZONE.LONDON).format("DD-MM-YYYY")}_${moment(activity.startTime).tz(TIMEZONE.LONDON).format("HHmm")}_${activity.testStationPNumber}_${activity.testerName}.xlsx`,
                                     fileBuffer: buffer,
-                                    testResults
+                                    testResults,
+                                    waitActivities
                                 };
                             });
                     });

--- a/src/services/ReportGenerationService.ts
+++ b/src/services/ReportGenerationService.ts
@@ -77,25 +77,6 @@ class ReportGenerationService {
                             detailsTemplate.expiryDate.value = moment(testType.testExpiryDate).tz(TIMEZONE.LONDON).format("DD/MM/YYYY");
                         }
 
-                       /* // Populate wait activities in the report
-                        for (let i = testResults.length, j = 0; i < template.reportTemplate.activityDetails.length && j < waitActivities.length; i++, j++) {
-                            console.log(`Populating wait activities details in report`);
-                            const detailsTemplate: any = template.reportTemplate.activityDetails[i];
-                            const waitActivityResult: any = waitActivities[j];
-                            let waitReasons: string = "";
-                            let additionalNotes: string = "";
-
-                            if (waitActivityResult.waitReason) {
-                                waitReasons = `Reason for waiting: ${waitActivityResult.waitReason};\r\n`;
-                            }
-                            if (waitActivityResult.notes) {
-                                additionalNotes = `Additional notes: ${waitActivityResult.notes};\r\n`;
-                            }
-
-                            detailsTemplate.activity.value = (waitActivityResult.activityType === "visit") ? ACTIVITY_TYPE.TEST : ACTIVITY_TYPE.WAIT_TIME;
-                            detailsTemplate.startTime.value = moment(waitActivityResult.startTime).tz(TIMEZONE.LONDON).format("HH:mm:ss");
-                            detailsTemplate.finishTime.value = moment(waitActivityResult.endTime).tz(TIMEZONE.LONDON).format("HH:mm:ss");
-                        }*/
                         return template.workbook.xlsx.writeBuffer()
                             .then((buffer: Excel.Buffer) => {
                                 return {

--- a/src/services/ReportGenerationService.ts
+++ b/src/services/ReportGenerationService.ts
@@ -95,7 +95,6 @@ class ReportGenerationService {
                             detailsTemplate.activity.value = (waitActivityResult.activityType === "visit") ? ACTIVITY_TYPE.TEST : ACTIVITY_TYPE.WAIT_TIME;
                             detailsTemplate.startTime.value = moment(waitActivityResult.startTime).tz(TIMEZONE.LONDON).format("HH:mm:ss");
                             detailsTemplate.finishTime.value = moment(waitActivityResult.endTime).tz(TIMEZONE.LONDON).format("HH:mm:ss");
-                            detailsTemplate.failureAdvisoryItemsQAIComments.value = waitReasons + additionalNotes;
                         }
                         return template.workbook.xlsx.writeBuffer()
                             .then((buffer: Excel.Buffer) => {

--- a/src/services/ReportGenerationService.ts
+++ b/src/services/ReportGenerationService.ts
@@ -77,14 +77,16 @@ class ReportGenerationService {
                             detailsTemplate.expiryDate.value = moment(testType.testExpiryDate).tz(TIMEZONE.LONDON).format("DD/MM/YYYY");
                         }
                         console.log(`Checking for wait activities details.`);
+                        console.log(`Two: wait Activities Size: ${waitActivities.length}`);
+                        console.log(`Two: TestResults Size: ${testResults.length}`);
                         // Populate wait activities in the report
-                        for (let i = testResults.length, j = 0; i < template.reportTemplate.activityDetails.length && j < waitActivities.length; i++, j++) {
+                        for (let i = testResults.length, j = 0; j < waitActivities.length; i++, j++) {
                             console.log(`Populating wait activities details in report`);
                             const detailsTemplate: any = template.reportTemplate.activityDetails[i];
                             const waitActivityResult: any = waitActivities[j];
                             let waitReasons: string = "";
                             let additionalNotes: string = "";
-                            
+
                             if (waitActivityResult.waitReason) {
                                 waitReasons = `Reason for waiting: ${waitActivityResult.waitReason};\r\n`;
                             }

--- a/src/services/SendATFReport.ts
+++ b/src/services/SendATFReport.ts
@@ -52,7 +52,7 @@ class SendATFReport {
       });
   }
 
-  private computeActivitiesList(testResultsList: ITestResults[], waitActivitiesList: IActivity[]) {
+  public computeActivitiesList(testResultsList: ITestResults[], waitActivitiesList: IActivity[]) {
     let list : IActivitiesList[] = [];
     // Adding Test activities to the list
     for (const [index, testResult] of testResultsList.entries()) {

--- a/src/services/SendATFReport.ts
+++ b/src/services/SendATFReport.ts
@@ -32,11 +32,12 @@ class SendATFReport {
  */
   public sendATFReport(generationServiceResponse: any, visit: any) {
     const testResultsList = generationServiceResponse.testResults;
+    const waitActivitiesList = generationServiceResponse.waitActivities;
     return this.s3BucketService.upload(`cvs-atf-reports-${process.env.BUCKET}`, generationServiceResponse.fileName, generationServiceResponse.fileBuffer)
       .then((result: any) => {
         return this.testStationsService.getTestStationEmail(visit.testStationPNumber)
           .then((response: any) => {
-            const sendNotificationData = this.notificationData.generateActivityDetails(visit, testResultsList);
+            const sendNotificationData = this.notificationData.generateActivityDetails(visit, testResultsList, waitActivitiesList);
             return this.notifyService.sendNotification(sendNotificationData, response[0].testStationEmails).then(() => {
               return result;
             }).catch((error: any) => {

--- a/src/services/SendATFReport.ts
+++ b/src/services/SendATFReport.ts
@@ -33,6 +33,7 @@ class SendATFReport {
  * @param visit - Data about the current visit
  */
   public sendATFReport(generationServiceResponse: any, visit: any) {
+    // Add testResults and waitActivities in a common list and sort it by startTime
     const activitiesList = this.computeActivitiesList(generationServiceResponse.testResults, generationServiceResponse.waitActivities);
     return this.s3BucketService.upload(`cvs-atf-reports-${process.env.BUCKET}`, generationServiceResponse.fileName, generationServiceResponse.fileBuffer)
       .then((result: any) => {
@@ -52,10 +53,15 @@ class SendATFReport {
       });
   }
 
+  /* Method to collate testResults and waitActivities into a common list
+   * and then sort them on startTime to display the activities in a sequence.
+   * @param testResultsList: testResults list
+   * @param waitActivitiesList: wait activities list
+   */
   public computeActivitiesList(testResultsList: ITestResults[], waitActivitiesList: IActivity[]) {
     let list : IActivitiesList[] = [];
     // Adding Test activities to the list
-    for (const [index, testResult] of testResultsList.entries()) {
+    for (const testResult of testResultsList) {
       const act: IActivitiesList = {
         startTime: testResult.testTypes.testTypeStartTimestamp,
         activityType: ACTIVITY_TYPE.TEST,
@@ -64,7 +70,7 @@ class SendATFReport {
       list.push(act);
     }
     // Adding Wait activities to the list
-    for (const [index, waitTime] of waitActivitiesList.entries()) {
+    for (const waitTime of waitActivitiesList) {
       const act: IActivitiesList = {
         startTime: waitTime.startTime,
         activityType: ACTIVITY_TYPE.TIME_NOT_TESTING,
@@ -80,7 +86,7 @@ class SendATFReport {
       if (date < dateToCompare) { return -1; }
       return 0;
     };
-    console.log(`Sorting the list`);
+    // Sort the list by startTime
     list.sort(sortDateAsc);
     return list;
   }

--- a/src/utils/generateNotificationData.ts
+++ b/src/utils/generateNotificationData.ts
@@ -11,6 +11,7 @@ class NotificationData {
    */
   public generateActivityDetails(visit: any, testResultsList: any, waitActivitiesList: any) {
     let list : IActivitiesList[] = [];
+    console.log(`Pushing Test activities to the list`);
     for (const [index, testResult] of testResultsList.entries()) {
       const act: IActivitiesList = {
         startTime: testResult.testTypes.testTypeStartTimestamp,
@@ -19,6 +20,8 @@ class NotificationData {
       }
       list.push(act);
     }
+    console.log(`1: List Len : ${list.length}`);
+    console.log(`Pushing Wait activities to the list`);
     for (const [index, waitTime] of waitActivitiesList.entries()) {
       const act: IActivitiesList = {
         startTime: waitTime.startTime,
@@ -27,15 +30,16 @@ class NotificationData {
       }
       list.push(act);
     }
-    list.sort((n1,n2) => {
-      if(n1.startTime > n2.startTime){
-        return 1;
-      }
-      if(n1.startTime > n2.startTime){
-        return -1;
-      }
+    console.log(`2: List Len : ${list.length}`);
+    const sortDateAsc = (date1: any, date2: any) => {
+      const date = new Date(date1.startTime).toISOString();
+      const dateToCompare = new Date(date2.startTime).toISOString();
+      if (date > dateToCompare) { return 1; }
+      if (date < dateToCompare) { return -1; }
       return 0;
-    });
+    };
+    console.log(`Sorting the list`);
+    list.sort(sortDateAsc);
 
     const personalization: any = {};
     personalization.testStationPNumber = visit.testStationPNumber;

--- a/src/utils/generateNotificationData.ts
+++ b/src/utils/generateNotificationData.ts
@@ -27,9 +27,8 @@ class NotificationData {
       ^• Result: ${this.capitalise(testResult.testTypes.testResult)}`
       + `${testResult.testTypes.certificateNumber ? `\n^• Certificate number: ${testResult.testTypes.certificateNumber}` : ""}`
       + `${testResult.testTypes.testExpiryDate ? `\n^• Expiry date: ${this.formatDateAndTime(testResult.testTypes.testExpiryDate, "date")}` : ""}`
-      + `${(index < testResultsList.length - 1) ? `\n---\n` : "\n"}`; // Add divider line if all BUT last entry
+      + `${(index < (testResultsList.length + waitActivitiesList.length) - 1) ? `\n---\n` : "\n"}`; // Add divider line if all BUT last entry
     }
-    console.log(`Populating wait times in atf report, Len: ${waitActivitiesList.length}`);
     personalization.activityType = ACTIVITY_TYPE.TIME_NOT_TESTING;
     for (const [index, waitTime] of waitActivitiesList.entries()) {
       personalization.activityDetails += `^#${this.capitalise(personalization.activityType)}

--- a/src/utils/generateNotificationData.ts
+++ b/src/utils/generateNotificationData.ts
@@ -1,8 +1,8 @@
 import moment = require("moment-timezone");
 import { ACTIVITY_TYPE, TIMEZONE } from "../assets/enum";
+import { IActivitiesList } from "../models";
 
 class NotificationData {
-
   /**
    * Generates the activity details for the ATF Report template
    * @param activity - activity that will be added in the email
@@ -10,6 +10,33 @@ class NotificationData {
    * @return personalization - Array that contains the entries for each activity and test result
    */
   public generateActivityDetails(visit: any, testResultsList: any, waitActivitiesList: any) {
+    let list : IActivitiesList[] = [];
+    for (const [index, testResult] of testResultsList.entries()) {
+      const act: IActivitiesList = {
+        startTime: testResult.testTypes.testTypeStartTimestamp,
+        activityType: ACTIVITY_TYPE.TEST,
+        activity: testResult
+      }
+      list.push(act);
+    }
+    for (const [index, waitTime] of waitActivitiesList.entries()) {
+      const act: IActivitiesList = {
+        startTime: waitTime.startTime,
+        activityType: ACTIVITY_TYPE.TIME_NOT_TESTING,
+        activity: waitTime
+      }
+      list.push(act);
+    }
+    list.sort((n1,n2) => {
+      if(n1.startTime > n2.startTime){
+        return 1;
+      }
+      if(n1.startTime > n2.startTime){
+        return -1;
+      }
+      return 0;
+    });
+
     const personalization: any = {};
     personalization.testStationPNumber = visit.testStationPNumber;
     personalization.testerName = visit.testerName;
@@ -18,7 +45,29 @@ class NotificationData {
     personalization.endTime = this.formatDateAndTime(visit.endTime, "time");
     personalization.testStationName = visit.testStationName;
     personalization.activityDetails = "";
-    personalization.activityType = (visit.activityType === "visit") ? ACTIVITY_TYPE.TEST : ACTIVITY_TYPE.WAIT_TIME;
+    //personalization.activityType = (visit.activityType === "visit") ? ACTIVITY_TYPE.TEST : ACTIVITY_TYPE.WAIT_TIME;
+    for (const [index, act] of list.entries()) {
+      if(act.activityType === ACTIVITY_TYPE.TEST) {
+        console.log(`Populating test activity`);
+        personalization.activityDetails += `^#${this.capitalise(ACTIVITY_TYPE.TEST)} (${act.activity.vrm})
+      ^• Time: ${this.formatDateAndTime(act.activity.testTypes.testTypeStartTimestamp, "time")} - ${this.formatDateAndTime(act.activity.testTypes.testTypeEndTimeStamp, "time")}
+      ^• Test description: ${act.activity.testTypes.testTypeName}
+      ^• Axles / Seats: ${act.activity.numberOfSeats}
+      ^• Result: ${this.capitalise(act.activity.testTypes.testResult)}`
+            + `${act.activity.testTypes.certificateNumber ? `\n^• Certificate number: ${act.activity.testTypes.certificateNumber}` : ""}`
+            + `${act.activity.testTypes.testExpiryDate ? `\n^• Expiry date: ${this.formatDateAndTime(act.activity.testTypes.testExpiryDate, "date")}` : ""}`
+            + `${(index < list.length - 1) ? `\n---\n` : "\n"}`; // Add divider line if all BUT last entry
+      }
+      if(act.activityType === ACTIVITY_TYPE.TIME_NOT_TESTING) {
+        console.log(`Populating wait activity`);
+        personalization.activityDetails += `^#${this.capitalise(ACTIVITY_TYPE.TIME_NOT_TESTING)}
+      ^• Time: ${this.formatDateAndTime(act.activity.startTime, "time")} - ${this.formatDateAndTime(act.activity.endTime, "time")}
+      ^• Reason: ${act.activity.waitReason}`
+            + `${(index < list.length - 1) ? `\n---\n` : "\n"}`; // Add divider line if all BUT last entry
+      }
+    }
+
+/*
     for (const [index, testResult] of testResultsList.entries()) {
       personalization.activityDetails += `^#${this.capitalise(personalization.activityType)} (${testResult.vrm})
       ^• Time: ${this.formatDateAndTime(testResult.testTypes.testTypeStartTimestamp, "time")} - ${this.formatDateAndTime(testResult.testTypes.testTypeEndTimeStamp, "time")}
@@ -35,7 +84,7 @@ class NotificationData {
       ^• Time: ${this.formatDateAndTime(waitTime.startTime, "time")} - ${this.formatDateAndTime(waitTime.endTime, "time")}
       ^• Reason: ${waitTime.waitReason}`
           + `${(index < waitActivitiesList.length - 1) ? `\n---\n` : "\n"}`; // Add divider line if all BUT last entry
-    }
+    }*/
     return personalization;
   }
 

--- a/src/utils/generateNotificationData.ts
+++ b/src/utils/generateNotificationData.ts
@@ -19,21 +19,21 @@ class NotificationData {
     personalization.endTime = this.formatDateAndTime(visit.endTime, "time");
     personalization.testStationName = visit.testStationName;
     personalization.activityDetails = "";
-    for (const [index, act] of activitiesList.entries()) {
-      if(act.activityType === ACTIVITY_TYPE.TEST) {
-        personalization.activityDetails += `^#${this.capitalise(ACTIVITY_TYPE.TEST)} (${act.activity.vrm})
-      ^• Time: ${this.formatDateAndTime(act.activity.testTypes.testTypeStartTimestamp, "time")} - ${this.formatDateAndTime(act.activity.testTypes.testTypeEndTimeStamp, "time")}
-      ^• Test description: ${act.activity.testTypes.testTypeName}
-      ^• Axles / Seats: ${act.activity.numberOfSeats}
-      ^• Result: ${this.capitalise(act.activity.testTypes.testResult)}`
-            + `${act.activity.testTypes.certificateNumber ? `\n^• Certificate number: ${act.activity.testTypes.certificateNumber}` : ""}`
-            + `${act.activity.testTypes.testExpiryDate ? `\n^• Expiry date: ${this.formatDateAndTime(act.activity.testTypes.testExpiryDate, "date")}` : ""}`
+    for (const [index, event] of activitiesList.entries()) {
+      if(event.activityType === ACTIVITY_TYPE.TEST) {
+        personalization.activityDetails += `^#${this.capitalise(ACTIVITY_TYPE.TEST)} (${event.activity.vrm})
+      ^• Time: ${this.formatDateAndTime(event.activity.testTypes.testTypeStartTimestamp, "time")} - ${this.formatDateAndTime(event.activity.testTypes.testTypeEndTimeStamp, "time")}
+      ^• Test description: ${event.activity.testTypes.testTypeName}
+      ^• Axles / Seats: ${event.activity.numberOfSeats}
+      ^• Result: ${this.capitalise(event.activity.testTypes.testResult)}`
+            + `${event.activity.testTypes.certificateNumber ? `\n^• Certificate number: ${event.activity.testTypes.certificateNumber}` : ""}`
+            + `${event.activity.testTypes.testExpiryDate ? `\n^• Expiry date: ${this.formatDateAndTime(event.activity.testTypes.testExpiryDate, "date")}` : ""}`
             + `${(index < activitiesList.length - 1) ? `\n---\n` : "\n"}`; // Add divider line if all BUT last entry
       }
-      if(act.activityType === ACTIVITY_TYPE.TIME_NOT_TESTING) {
+      if(event.activityType === ACTIVITY_TYPE.TIME_NOT_TESTING) {
         personalization.activityDetails += `^#${this.capitalise(ACTIVITY_TYPE.TIME_NOT_TESTING)}
-      ^• Time: ${this.formatDateAndTime(act.activity.startTime, "time")} - ${this.formatDateAndTime(act.activity.endTime, "time")}
-      ^• Reason: ${act.activity.waitReason}`
+      ^• Time: ${this.formatDateAndTime(event.activity.startTime, "time")} - ${this.formatDateAndTime(event.activity.endTime, "time")}
+      ^• Reason: ${event.activity.waitReason}`
             + `${(index < activitiesList.length - 1) ? `\n---\n` : "\n"}`; // Add divider line if all BUT last entry
       }
     }

--- a/src/utils/generateNotificationData.ts
+++ b/src/utils/generateNotificationData.ts
@@ -2,13 +2,14 @@ import moment = require("moment-timezone");
 import { ACTIVITY_TYPE, TIMEZONE } from "../assets/enum";
 
 class NotificationData {
+
   /**
    * Generates the activity details for the ATF Report template
    * @param activity - activity that will be added in the email
    * @param testResultsList - list of test results that will be added in the email
    * @return personalization - Array that contains the entries for each activity and test result
    */
-  public generateActivityDetails(visit: any, testResultsList: any) {
+  public generateActivityDetails(visit: any, testResultsList: any, waitActivitiesList: any) {
     const personalization: any = {};
     personalization.testStationPNumber = visit.testStationPNumber;
     personalization.testerName = visit.testerName;
@@ -27,6 +28,14 @@ class NotificationData {
       + `${testResult.testTypes.certificateNumber ? `\n^• Certificate number: ${testResult.testTypes.certificateNumber}` : ""}`
       + `${testResult.testTypes.testExpiryDate ? `\n^• Expiry date: ${this.formatDateAndTime(testResult.testTypes.testExpiryDate, "date")}` : ""}`
       + `${(index < testResultsList.length - 1) ? `\n---\n` : "\n"}`; // Add divider line if all BUT last entry
+    }
+    console.log(`Populating wait times in atf report, Len: ${waitActivitiesList.length}`);
+    personalization.activityType = ACTIVITY_TYPE.TIME_NOT_TESTING;
+    for (const [index, waitTime] of waitActivitiesList.entries()) {
+      personalization.activityDetails += `^#${this.capitalise(personalization.activityType)}
+      ^• Time: ${this.formatDateAndTime(waitTime.startTime, "time")} - ${this.formatDateAndTime(waitTime.endTime, "time")}
+      ^• Reason: ${waitTime.waitReason}`
+          + `${(index < waitActivitiesList.length - 1) ? `\n---\n` : "\n"}`; // Add divider line if all BUT last entry
     }
     return personalization;
   }

--- a/tests/resources/wait-time-response.json
+++ b/tests/resources/wait-time-response.json
@@ -1,0 +1,8 @@
+{
+  "headers": {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Credentials": true
+  },
+  "statusCode": 200,
+  "body": "[{\"startTime\":\"2019-01-14T10:36:33.987Z\",\"endTime\":\"2019-01-14T10:36:33.987Z\",\"waitReason\":\"Break\"}]"
+}

--- a/tests/resources/wait-time-response.json
+++ b/tests/resources/wait-time-response.json
@@ -4,5 +4,5 @@
     "Access-Control-Allow-Credentials": true
   },
   "statusCode": 200,
-  "body": "[{\"startTime\":\"2019-01-14T10:36:33.987Z\",\"endTime\":\"2019-01-14T10:36:33.987Z\",\"waitReason\":\"Break\"}]"
+  "body": "[{\"startTime\":\"2019-01-14T10:42:33.987Z\",\"endTime\":\"2019-01-14T10:48:33.987Z\",\"waitReason\":\"Break\"}]"
 }

--- a/tests/unit/generateNotificationData.unitTest.ts
+++ b/tests/unit/generateNotificationData.unitTest.ts
@@ -34,8 +34,7 @@ describe("notificationData", () => {
         context("when parsing the visit and multiple test results", () => {
             it("should return a correct test stations emails with dividers", () => {
                 const testResultsArray = JSON.parse(testResultsListMultiTest.body);
-                const waitActivitiesArray = JSON.parse(waitActivitiesList.body);
-                const sendNotificationData = notificationData.generateActivityDetails(visit, sendAtfReport.computeActivitiesList(testResultsArray, waitActivitiesArray));
+                const sendNotificationData = notificationData.generateActivityDetails(visit, testResultsArray);
                 expect(sendNotificationData.testStationPNumber).to.equal(testResultsArray[0].testStationPNumber);
                 expect(sendNotificationData.testerName).to.equal(visit.testerName);
                 expect(sendNotificationData.startTimeDate).to.equal("14/01/2019");

--- a/tests/unit/generateNotificationData.unitTest.ts
+++ b/tests/unit/generateNotificationData.unitTest.ts
@@ -45,6 +45,9 @@ describe("notificationData", () => {
                 expect(countInstances(sendNotificationData.activityDetails,"---")).to.equal(2);
             });
         });
+
+        // TODO Add tests to verify the waitTime fields for "Time not Testing" activity added in ATF report.
+        // Verify for activityType, startTime, endTime, waitReason values.
     });
 
 

--- a/tests/unit/generateNotificationData.unitTest.ts
+++ b/tests/unit/generateNotificationData.unitTest.ts
@@ -4,21 +4,23 @@ import { NotificationData } from "../../src/utils/generateNotificationData";
 import * as fs from "fs";
 import * as path from "path";
 import { Configuration } from "../../src/utils/Configuration";
+import {SendATFReport} from "../../src/services/SendATFReport";
 
 describe("notificationData", () => {
     context("report data generation", () => {
         const notificationData: NotificationData = new NotificationData();
+        const sendAtfReport: SendATFReport = new SendATFReport();
         const event: any = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../resources/queue-event.json"), "utf8"));
         const visit: any = JSON.parse(event.Records[0].body);
         const testResultsList: any = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../resources/test-results-200-response.json"), "utf8"));
-        const waitActivitiesList: any = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../resources/test-results-200-response.json"), "utf8"));
+        const waitActivitiesList: any = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../resources/wait-time-response.json"), "utf8"));
         const testResultsListMultiTest: any = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../resources/test-results-200-response-multi-test.json"), "utf8"));
         LambdaMockService.populateFunctions();
         context("when parsing the visit and the test results", () => {
             it("should return a correct test stations emails", () => {
                 const testResultsArray = JSON.parse(testResultsList.body);
                 const waitActivitiesArray = JSON.parse(waitActivitiesList.body);
-                const sendNotificationData = notificationData.generateActivityDetails(visit, testResultsArray, waitActivitiesArray);
+                const sendNotificationData = notificationData.generateActivityDetails(visit, sendAtfReport.computeActivitiesList(testResultsArray, waitActivitiesArray));
                 expect(sendNotificationData.testStationPNumber).to.equal(testResultsArray[0].testStationPNumber);
                 expect(sendNotificationData.testerName).to.equal(visit.testerName);
                 expect(sendNotificationData.startTimeDate).to.equal("14/01/2019");
@@ -33,7 +35,7 @@ describe("notificationData", () => {
             it("should return a correct test stations emails with dividers", () => {
                 const testResultsArray = JSON.parse(testResultsListMultiTest.body);
                 const waitActivitiesArray = JSON.parse(waitActivitiesList.body);
-                const sendNotificationData = notificationData.generateActivityDetails(visit, testResultsArray, waitActivitiesArray);
+                const sendNotificationData = notificationData.generateActivityDetails(visit, sendAtfReport.computeActivitiesList(testResultsArray, waitActivitiesArray));
                 expect(sendNotificationData.testStationPNumber).to.equal(testResultsArray[0].testStationPNumber);
                 expect(sendNotificationData.testerName).to.equal(visit.testerName);
                 expect(sendNotificationData.startTimeDate).to.equal("14/01/2019");

--- a/tests/unit/generateNotificationData.unitTest.ts
+++ b/tests/unit/generateNotificationData.unitTest.ts
@@ -11,12 +11,14 @@ describe("notificationData", () => {
         const event: any = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../resources/queue-event.json"), "utf8"));
         const visit: any = JSON.parse(event.Records[0].body);
         const testResultsList: any = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../resources/test-results-200-response.json"), "utf8"));
+        const waitActivitiesList: any = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../resources/test-results-200-response.json"), "utf8"));
         const testResultsListMultiTest: any = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../resources/test-results-200-response-multi-test.json"), "utf8"));
         LambdaMockService.populateFunctions();
         context("when parsing the visit and the test results", () => {
             it("should return a correct test stations emails", () => {
                 const testResultsArray = JSON.parse(testResultsList.body);
-                const sendNotificationData = notificationData.generateActivityDetails(visit, testResultsArray);
+                const waitActivitiesArray = JSON.parse(waitActivitiesList.body);
+                const sendNotificationData = notificationData.generateActivityDetails(visit, testResultsArray, waitActivitiesArray);
                 expect(sendNotificationData.testStationPNumber).to.equal(testResultsArray[0].testStationPNumber);
                 expect(sendNotificationData.testerName).to.equal(visit.testerName);
                 expect(sendNotificationData.startTimeDate).to.equal("14/01/2019");
@@ -30,7 +32,8 @@ describe("notificationData", () => {
         context("when parsing the visit and multiple test results", () => {
             it("should return a correct test stations emails with dividers", () => {
                 const testResultsArray = JSON.parse(testResultsListMultiTest.body);
-                const sendNotificationData = notificationData.generateActivityDetails(visit, testResultsArray);
+                const waitActivitiesArray = JSON.parse(waitActivitiesList.body);
+                const sendNotificationData = notificationData.generateActivityDetails(visit, testResultsArray, waitActivitiesArray);
                 expect(sendNotificationData.testStationPNumber).to.equal(testResultsArray[0].testStationPNumber);
                 expect(sendNotificationData.testerName).to.equal(visit.testerName);
                 expect(sendNotificationData.startTimeDate).to.equal("14/01/2019");

--- a/tests/unit/notificationService.unitTest.ts
+++ b/tests/unit/notificationService.unitTest.ts
@@ -6,19 +6,21 @@ import { NotifyClient } from "notifications-node-client";
 import * as fs from "fs";
 import * as path from "path";
 import { NotificationData } from "../../src/utils/generateNotificationData";
+import {SendATFReport} from "../../src/services/SendATFReport";
 
 describe("notification service", () => {
     context("send email", () => {
         const notifyClient = new NotifyClient(Configuration.getInstance().getGovNotifyConfig().api_key);
         const notifyService: NotificationService = new NotificationService(notifyClient);
+        const sendAtfReport: SendATFReport = new SendATFReport();
         const event: any = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../resources/queue-event.json"), "utf8"));
         const visit: any = JSON.parse(event.Records[0].body);
         const testResultsList: any = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../resources/test-results-200-response.json"), "utf8"));
-        const waitActivitiesList: any = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../resources/test-results-200-response.json"), "utf8"));
+        const waitActivitiesList: any = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../resources/wait-time-response.json"), "utf8"));
         const testResultsArray = JSON.parse(testResultsList.body);
         const waitActivitesArray = JSON.parse(waitActivitiesList.body);
         const notificationData: NotificationData = new NotificationData();
-        const sendNotificationData = notificationData.generateActivityDetails(visit, testResultsArray, waitActivitesArray);
+        const sendNotificationData = notificationData.generateActivityDetails(visit, sendAtfReport.computeActivitiesList(testResultsArray, waitActivitesArray));
 
         context("when sending email with the correct data and emails", () => {
             it("should return a correct response", () => {

--- a/tests/unit/notificationService.unitTest.ts
+++ b/tests/unit/notificationService.unitTest.ts
@@ -14,9 +14,11 @@ describe("notification service", () => {
         const event: any = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../resources/queue-event.json"), "utf8"));
         const visit: any = JSON.parse(event.Records[0].body);
         const testResultsList: any = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../resources/test-results-200-response.json"), "utf8"));
+        const waitActivitiesList: any = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../resources/test-results-200-response.json"), "utf8"));
         const testResultsArray = JSON.parse(testResultsList.body);
+        const waitActivitesArray = JSON.parse(waitActivitiesList.body);
         const notificationData: NotificationData = new NotificationData();
-        const sendNotificationData = notificationData.generateActivityDetails(visit, testResultsArray);
+        const sendNotificationData = notificationData.generateActivityDetails(visit, testResultsArray, waitActivitesArray);
 
         context("when sending email with the correct data and emails", () => {
             it("should return a correct response", () => {

--- a/tests/unit/reportGenService.unitTest.ts
+++ b/tests/unit/reportGenService.unitTest.ts
@@ -8,10 +8,12 @@ import { TestResultsService } from "../../src/services/TestResultsService";
 import { IActivity } from "../../src/models";
 import * as Excel from "exceljs";
 import { Duplex } from "stream";
+import {ActivitiesService} from "../../src/services/ActivitiesService";
 
 describe("ReportGenerationService", () => {
         const testResultsService: TestResultsService = Injector.resolve<TestResultsService>(TestResultsService, [LambdaMockService]);
-        const reportGenerationService: ReportGenerationService = new ReportGenerationService(testResultsService);
+        const activitiesService: ActivitiesService = Injector.resolve<ActivitiesService>(ActivitiesService, [LambdaMockService]);
+        const reportGenerationService: ReportGenerationService = new ReportGenerationService(testResultsService, activitiesService);
         LambdaMockService.populateFunctions();
 
         context("when generating a template", () => {

--- a/tests/unit/reportGenService.unitTest.ts
+++ b/tests/unit/reportGenService.unitTest.ts
@@ -108,7 +108,10 @@ describe("ReportGenerationService", () => {
 
                     expect(reportSheet.getCell("C24").value).to.equal("Activity");
                     // tslint:disable-next-line
-                    expect(reportSheet.getCell("C25").value).to.be.null;
+
+                  let value = reportSheet.getCell("C25").value;
+                  console.log("C25", value);
+                  expect(value).to.be.null;
                 });
             });
         });

--- a/tests/unit/reportGenService.unitTest.ts
+++ b/tests/unit/reportGenService.unitTest.ts
@@ -92,27 +92,29 @@ describe("ReportGenerationService", () => {
                     });
             });
 
-            context("and testResults returns cancelled tests", ()=> {
-                it("should generate an empty report", async () => {
-                    // TestResultsService.prototype.getTestResults = jest.fn().mockImplementation(() => {return cancelledTest});
-                    LambdaMockService.changeResponse("cvs-svc-test-results", "tests/resources/cancelled-test-result.json");
-
-                    const output = await reportGenerationService.generateATFReport(activity);
-                    const workbook = new Excel.Workbook();
-                    const stream = new Duplex();
-                    stream.push(output.fileBuffer); // Convert the incoming file to a readable stream
-                    stream.push(null);
-
-                    const excelFile = await workbook.xlsx.read(stream);
-                    const reportSheet: Excel.Worksheet = excelFile.getWorksheet(1);
-
-                    expect(reportSheet.getCell("C24").value).to.equal("Activity");
-                    // tslint:disable-next-line
-
-                  let value = reportSheet.getCell("C25").value;
-                  console.log("C25", value);
-                  expect(value).to.be.null;
-                });
-            });
+            // Test disabled as Test Results should no longer return cancelled tests (CVSB-7623)
+            //
+            // context("and testResults returns cancelled tests", ()=> {
+            //     it("should generate an empty report", async () => {
+            //         // TestResultsService.prototype.getTestResults = jest.fn().mockImplementation(() => {return cancelledTest});
+            //         LambdaMockService.changeResponse("cvs-svc-test-results", "tests/resources/cancelled-test-result.json");
+            //
+            //         const output = await reportGenerationService.generateATFReport(activity);
+            //         const workbook = new Excel.Workbook();
+            //         const stream = new Duplex();
+            //         stream.push(output.fileBuffer); // Convert the incoming file to a readable stream
+            //         stream.push(null);
+            //
+            //         const excelFile = await workbook.xlsx.read(stream);
+            //         const reportSheet: Excel.Worksheet = excelFile.getWorksheet(1);
+            //
+            //         expect(reportSheet.getCell("C24").value).to.equal("Activity");
+            //         // tslint:disable-next-line
+            //
+            //       let value = reportSheet.getCell("C25").value;
+            //       console.log("C25", value);
+            //       expect(value).to.be.null;
+            //     });
+            // });
         });
     });

--- a/tests/unit/sendATFReport.unitTest.ts
+++ b/tests/unit/sendATFReport.unitTest.ts
@@ -1,69 +1,99 @@
-import { expect } from "chai";
 import { SendATFReport } from "../../src/services/SendATFReport";
-import { Injector } from "../../src/models/injector/Injector";
-import { S3BucketMockService } from "../models/S3BucketMockService";
-import { LambdaMockService } from "../models/LambdaMockService";
-import { TestStationsService } from "../../src/services/TestStationsService";
 
 describe("sendATFReport", () => {
-    context("ATF report upload to S3 Bucket and sent by email", () => {
-      const visit = {
-        id: "5e4bd304-446e-4678-8289-d34fca9256e9",
-        activityType: "visit",
-        testStationName: "Rowe, Wunsch and Wisoky",
-        testStationPNumber: "87-1369569",
-        testStationEmail: "teststationname@dvsa.gov.uk",
-        testStationType: "gvts",
-        testerName: "Gica",
-        testerStaffId: "1",
-        startTime: "2019-01-14T08:47:33.987Z",
-        endTime: "2019-01-14T15:36:33.987Z"
+  context("ATF report upload to S3 Bucket and sent by email", () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+    const visit = {
+      id: "5e4bd304-446e-4678-8289-d34fca9256e9",
+      activityType: "visit",
+      testStationName: "Rowe, Wunsch and Wisoky",
+      testStationPNumber: "87-1369569",
+      testStationEmail: "teststationname@dvsa.gov.uk",
+      testStationType: "gvts",
+      testerName: "Gica",
+      testerStaffId: "1",
+      startTime: "2019-01-14T08:47:33.987Z",
+      endTime: "2019-01-14T15:36:33.987Z"
+    };
+    const generationServiceResponse = {
+        waitActivities:[],
+      testResults:
+        [ { testerStaffId: "1",
+          vrm: "JY58FPP",
+          testStationPNumber: "87-1369569",
+          preparerId: "ak4434",
+          numberOfSeats: 45,
+          testStartTimestamp: "2019-01-14T10:36:33.987Z",
+          testEndTimestamp: "2019-01-14T10:36:33.987Z",
+          testTypes: [Object],
+          vin: "XMGDE02FS0H012345",
+          vehicleType: "psv" } ],
+      fileName: "ATFReport_14-01-2019_0847_87-1369569_Gica.xlsx",
+      fileBuffer:
+        "<Buffer 50 4b 03 04 0a 00 00 00 08 00 c6 64 c3 4e 19 f8 08 be 60 01 00 00 39 05 00 00 13 00 00 00 5b 43 6f 6e 74 65 6e 74 5f 54 79 70 65 73 5d 2e 78 6d 6c ad ... >",
       };
-      const generationServiceResponse = {
-          waitActivities:[],
-        testResults:
-          [ { testerStaffId: "1",
-            vrm: "JY58FPP",
-            testStationPNumber: "87-1369569",
-            preparerId: "ak4434",
-            numberOfSeats: 45,
-            testStartTimestamp: "2019-01-14T10:36:33.987Z",
-            testEndTimestamp: "2019-01-14T10:36:33.987Z",
-            testTypes: [Object],
-            vin: "XMGDE02FS0H012345",
-            vehicleType: "psv" } ],
-        fileName: "ATFReport_14-01-2019_0847_87-1369569_Gica.xlsx",
-        fileBuffer:
-          "<Buffer 50 4b 03 04 0a 00 00 00 08 00 c6 64 c3 4e 19 f8 08 be 60 01 00 00 39 05 00 00 13 00 00 00 5b 43 6f 6e 74 65 6e 74 5f 54 79 70 65 73 5d 2e 78 6d 6c ad ... >",
-        };
 
-      it("When the bucket is not defined should throw error", () => {
+    context("When the s3Bucket service throws an error", () => {
+      it("should bubble up that error", () => {
         const sendATFReport: SendATFReport = new SendATFReport();
-        sendATFReport.s3BucketService = Injector.resolve<S3BucketMockService>(S3BucketMockService);
+        sendATFReport.s3BucketService.upload = jest.fn().mockRejectedValue(new Error("Nope"));
         return sendATFReport.sendATFReport(generationServiceResponse, visit).then((response: any) => {
-          expect.fail();
         }).catch((error: any) => {
-          expect(error.statusCode).to.be.equal(404);
-          expect(error.message).to.be.equal("The specified bucket does not exist.");
-        });
-      });
-
-      it("When the bucket is defined should return", () => {
-        LambdaMockService.populateFunctions();
-        const sendATFReport: SendATFReport = new SendATFReport();
-        sendATFReport.testStationsService = Injector.resolve<TestStationsService>(TestStationsService, [LambdaMockService]);
-        sendATFReport.s3BucketService = Injector.resolve<S3BucketMockService>(S3BucketMockService);
-        S3BucketMockService.buckets.push({
-          files: ["ATFReport_14-01-2019_0847_87-1369569_Gica.xlsx"],
-          bucketName: `cvs-atf-reports-${process.env.BUCKET}`
-        });
-        return sendATFReport.sendATFReport(generationServiceResponse, visit).then((response: any) => {
-          expect(response.Bucket).to.be.equal(`cvs-atf-reports-${process.env.BUCKET}`);
-          expect(response.Key).to.be.equal("ATFReport_14-01-2019_0847_87-1369569_Gica.xlsx");
-          expect(response.Location.length).to.be.at.least(1);
-          expect(response.ETag.length).to.be.at.least(1);
-
+          expect(error.message).toEqual("Nope");
         });
       });
     });
+
+    context("When the Test Stations service throws an error", () => {
+      it("should bubble up that error", () => {
+        const sendATFReport: SendATFReport = new SendATFReport();
+        sendATFReport.s3BucketService.upload = jest.fn().mockResolvedValue("ok");
+        sendATFReport.testStationsService.getTestStationEmail = jest.fn().mockRejectedValue(new Error("It Broke"));
+        return sendATFReport.sendATFReport(generationServiceResponse, visit).then((response: any) => {
+        }).catch((error: any) => {
+          expect(error.message).toEqual("It Broke");
+        });
+      });
+    });
+
+    context("When the Notification service throws an error", () => {
+      it("should bubble up that error", () => {
+        const sendATFReport: SendATFReport = new SendATFReport();
+        sendATFReport.s3BucketService.upload = jest.fn().mockResolvedValue("ok");
+        sendATFReport.testStationsService.getTestStationEmail = jest.fn().mockResolvedValue([{
+          "testStationPNumber": "09-4129632",
+          "testStationEmails": [
+            "teststationname@dvsa.gov.uk"
+          ],
+          "testStationId": "9"
+        }]);
+        sendATFReport.notifyService.sendNotification = jest.fn().mockRejectedValue(new Error("It Broke"));
+        return sendATFReport.sendATFReport(generationServiceResponse, visit).then((response: any) => {
+        }).catch((error: any) => {
+          expect(error.message).toEqual("It Broke");
+        });
+      });
+    });
+
+    context("When services succeed", () => {
+      it("should return success and details of storage", () => {
+        const sendATFReport: SendATFReport = new SendATFReport();
+        sendATFReport.s3BucketService.upload = jest.fn().mockResolvedValue("details from s3");
+        sendATFReport.testStationsService.getTestStationEmail = jest.fn().mockResolvedValue([{
+          "testStationPNumber": "09-4129632",
+          "testStationEmails": [
+            "teststationname@dvsa.gov.uk"
+          ],
+          "testStationId": "9"
+        }]);
+        sendATFReport.notifyService.sendNotification = jest.fn().mockResolvedValue("We won!")
+        expect.assertions(1);
+        return sendATFReport.sendATFReport(generationServiceResponse, visit).then((response: any) => {
+          expect(response).toEqual("details from s3");
+        });
+      })
+    });
+  });
 });

--- a/tests/unit/sendATFReport.unitTest.ts
+++ b/tests/unit/sendATFReport.unitTest.ts
@@ -20,6 +20,7 @@ describe("sendATFReport", () => {
         endTime: "2019-01-14T15:36:33.987Z"
       };
       const generationServiceResponse = {
+          waitActivities:[],
         testResults:
           [ { testerStaffId: "1",
             vrm: "JY58FPP",


### PR DESCRIPTION
Changes done to include wait activities in ATF report sent in email.
Logic Impl: Adding testResults and waitActivities fetched for a visit into a common list and then sorting them based on startTime. And then this list is used to populate the data in the report.

Tested on AWS and email looks as expected. Unit tests are yet to be added for the same. They are only fixed currently to handle arg changes. Since mocks dont exist for notify service, running these tests locally is challenging.

Please review and provide comments if any.