### PR TITLE
CVSB-11826 - correct visit time displayed in atf email

### DIFF
--- a/src/utils/generateNotificationData.ts
+++ b/src/utils/generateNotificationData.ts
@@ -24,7 +24,7 @@ class NotificationData {
         const axlesSeats = (event.activity.vehicleType === VEHICLE_TYPES.PSV) ? event.activity.numberOfSeats : event.activity.noOfAxles;
         const vrmTrailerId = (event.activity.vehicleType === VEHICLE_TYPES.TRL) ? event.activity.trailerId : event.activity.vrm;
         personalization.activityDetails += `^#${this.capitalise(event.activityType)} (${vrmTrailerId})
-      ^• Time: ${this.formatDateAndTime(event.activity.testTypes.testTypeStartTimestamp, "time")} - ${this.formatDateAndTime(event.activity.testTypes.testTypeEndTimestamp, "time")}
+      ^• Time: ${this.formatDateAndTime(event.activity.testStartTimestamp, "time")} - ${this.formatDateAndTime(event.activity.testEndTimestamp, "time")}
       ^• Test description: ${event.activity.testTypes.testTypeName}
       ^• Axles / Seats: ${axlesSeats}
       ^• Result: ${this.capitalise(event.activity.testTypes.testResult)}`

--- a/tests/unit/generateNotificationData.unitTest.ts
+++ b/tests/unit/generateNotificationData.unitTest.ts
@@ -18,6 +18,8 @@ describe("notificationData", () => {
     context("when parsing the visit and the test results", () => {
       it("should return a correct test stations emails", () => {
         const testResultsArray = TestResultsService.prototype.expandTestResults(JSON.parse(testResultsList.body));
+        testResultsArray[0].testStartTimestamp = "2019-01-14T10:05:16.987Z";
+        testResultsArray[0].testEndTimestamp = "2019-01-14T10:40:02.987Z";
         const waitActivitiesArray = JSON.parse(waitActivitiesList.body);
         const sendNotificationData = notificationData.generateActivityDetails(visit, sendAtfReport.computeActivitiesList(testResultsArray, waitActivitiesArray));
         const detailsLines = sendNotificationData.activityDetails.split("\n");
@@ -28,6 +30,8 @@ describe("notificationData", () => {
         expect(sendNotificationData.startTime).toEqual("08:47:33");
         expect(sendNotificationData.endTime).toEqual("15:36:33");
         expect(sendNotificationData.activityDetails.length).not.toEqual(0);
+        // checking the correct time is displayed in the atf email
+        expect(detailsLines[1]).toContain("Time: 10:05:16 - 10:40:02");
       });
     });
 


### PR DESCRIPTION
Ticket that ensures the correct display of times in the ATF email.

https://jira.dvsacloud.uk/browse/CVSB-11826