### PR TITLE
chore(cvsb-19660): removing unused dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16880,12 +16880,6 @@
         }
       }
     },
-    "serverless-dependency-invoke": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/serverless-dependency-invoke/-/serverless-dependency-invoke-0.0.10.tgz",
-      "integrity": "sha512-Om7YnrlHoydomLxEz9mn+SsQjRU4J05bm4p/o7pG2TnePHEe6usQsTdcFJTRNdl0ayDchgRHPmUE2MjyMmfzxQ==",
-      "dev": true
-    },
     "serverless-offline": {
       "version": "5.12.1",
       "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-5.12.1.tgz",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "nyc": "^14.1.1",
     "prettier": "^2.3.2",
     "serverless": "^2.20.0",
-    "serverless-dependency-invoke": "^0.0.10",
     "serverless-offline": "^5.12.1",
     "serverless-plugin-tracing": "^2.0.0",
     "serverless-plugin-typescript": "^1.1.9",


### PR DESCRIPTION
## Remove unused dependency

Removing  serverless-dependency-invoke as it is not used
[link to ticket number](https://jira.dvsacloud.uk/browse/CVSB-19660)

## Checklist

- [x] Branch is rebased against the latest develop
- [x] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [x] Link to the PR added to the repo
