### PR TITLE
VTA-83: Switch to use dev version of gov notify

### DIFF
--- a/src/assets/enum.ts
+++ b/src/assets/enum.ts
@@ -1,7 +1,3 @@
-export enum TEMPLATE_IDS {
-  ATF_REPORT_TEMPLATE = "368a62fa-f826-4be6-92c3-c555e3d7e0a3",
-}
-
 export enum ERRORS {
   MOT_CONFIG_NOT_DEFINED = "The MOT config is not defined in the config file.",
   DYNAMO_DB_CONFIG_NOT_DEFINED = "DynamoDB config is not defined in the config file.",
@@ -9,6 +5,7 @@ export enum ERRORS {
   ATF_CANT_BE_CREATED = "ATF Report can't be created.",
   EVENT_IS_EMPTY = "Event is empty",
   SECRET_ENV_VAR_NOT_EXIST = "SECRET_NAME environment variable does not exist.",
+  TEMPLATE_ID_ENV_VAR_NOT_EXIST = "TEMPLATE_ID environment variable does not exist.",
   SECRET_FILE_NOT_EXIST = "The secret file does not exist.",
   NOTIFY_CONFIG_NOT_SET = "The GovNotify configuration not set.",
 }

--- a/src/config/config.yml
+++ b/src/config/config.yml
@@ -45,3 +45,4 @@ notify:
     psv_prs: PSV_PRS.pdf
     vtg5: VTG5.pdf
     vtg5a: VTG5A.pdf
+  templateId: 306d864b-a56d-49eb-b3cc-6d23cf8bcc26

--- a/src/models/index.d.ts
+++ b/src/models/index.d.ts
@@ -29,6 +29,7 @@ interface IMOTConfig {
     vtg5: "VTG5.pdf";
     vtg5a: "VTG5A.pdf";
   };
+  templateId: string;
 }
 
 interface IActivity {

--- a/src/utils/Configuration.ts
+++ b/src/utils/Configuration.ts
@@ -14,7 +14,7 @@ class Configuration {
   private secretsClient: SecretsManager;
   private readonly secretPath = "../config/secrets.yml";
 
-  private constructor(configPath: string) {
+  constructor(configPath: string) {
     this.secretsClient = AWSXRay.captureAWSClient(new SecretsManager({ region: "eu-west-1" }));
     this.config = yml.readSync(configPath);
 

--- a/src/utils/Configuration.ts
+++ b/src/utils/Configuration.ts
@@ -93,6 +93,24 @@ class Configuration {
   }
 
   /**
+   * Retrieves the templateId from config file when running locally, else environment variable
+   */
+  public async getTemplateIdFromEV(): Promise<string> {
+    if (!process.env.BRANCH || process.env.BRANCH === "local") {
+      if (!this.config.notify.templateId) {
+        throw new Error(ERRORS.TEMPLATE_ID_ENV_VAR_NOT_EXIST);
+      } else {
+        return this.config.notify.templateId;
+      }
+    } else {
+      if (!process.env.TEMPLATE_ID) {
+        throw new Error(ERRORS.TEMPLATE_ID_ENV_VAR_NOT_EXIST);
+      }
+      return process.env.TEMPLATE_ID;
+    }
+  }
+
+  /**
    * Sets the secrets needed to use GovNotify
    * @returns Promise<void>
    */

--- a/tests/resources/badConfig.yml
+++ b/tests/resources/badConfig.yml
@@ -1,0 +1,2 @@
+notify:
+  templateId:

--- a/tests/unit/notificationService.unitTest.ts
+++ b/tests/unit/notificationService.unitTest.ts
@@ -4,7 +4,6 @@ import { SendATFReport } from "../../src/services/SendATFReport";
 import event from "../resources/queue-event.json";
 import testResultsList from "../resources/test-results-200-response.json";
 import waitActivitiesList from "../resources/wait-time-response.json";
-import { TEMPLATE_IDS } from "../../src/assets/enum";
 import { TestResultsService } from "../../src/services/TestResultsService";
 import mockConfig from "../util/mockConfig";
 
@@ -37,7 +36,7 @@ describe("notification service", () => {
         await notifyService.sendNotification(sendNotificationData, ["test@test.com"]);
         const args = sendEmailMock.mock.calls[0];
         const personalisation = args[2].personalisation;
-        expect(args[0]).toEqual(TEMPLATE_IDS.ATF_REPORT_TEMPLATE);
+        expect(args[0]).toEqual("306d864b-a56d-49eb-b3cc-6d23cf8bcc26");
         expect(args[1]).toEqual("test@test.com");
         expect(personalisation.testStationPNumber).toEqual(visit.testStationPNumber);
         expect(personalisation.testStationName).toEqual(visit.testStationName);


### PR DESCRIPTION
## Switch atf-report-gen serice to use dev version of gov notify

This piece of work was completed to switch the atf-report-gen service to use the dev gov notify account in non-prod environments.
[VTA-83](https://jira.dvsacloud.uk/browse/VTA-108)

## Checklist

- [X] Branch is rebased against the latest develop
- [X] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
