### PR TITLE
feat(cb2-13178): atf-report-gen - Update type definition version to allow 'vef' to be processed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/client-s3": "^3.550.0",
         "@aws-sdk/client-secrets-manager": "^3.549.0",
         "@aws-sdk/util-dynamodb": "^3.592.0",
-        "@dvsa/cvs-type-definitions": "7.1.0",
+        "@dvsa/cvs-type-definitions": "7.4.0",
         "@smithy/util-utf8": "^2.3.0",
         "aws-lambda": "^1.0.7",
         "aws-xray-sdk": "^3.6.0",
@@ -3018,9 +3018,9 @@
       }
     },
     "node_modules/@dvsa/cvs-type-definitions": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-7.1.0.tgz",
-      "integrity": "sha512-zvuzyBNu30wmjo9vkjmXTokoy3Gvii9Sj7y+AmQeqe0fp1HbJRF27nu68n457VHyQf+rDQACIVvDksGVXY8Cqg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-7.4.0.tgz",
+      "integrity": "sha512-MGiIQ2It0xBlu9n+RqgrnlEpsHWUoZFPqIGF4VcaMpTCgVzcNE9TriuJMmdGI6TiegzxByOIhYNNtjQYQ1x5cA==",
       "dependencies": {
         "ajv": "^8.12.0",
         "json-schema-deref-sync": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@dvsa/cvs-type-definitions": "7.1.0",
+    "@dvsa/cvs-type-definitions": "7.4.0",
     "@aws-sdk/client-lambda": "^3.549.0",
     "@aws-sdk/client-s3": "^3.550.0",
     "@aws-sdk/client-secrets-manager": "^3.549.0",


### PR DESCRIPTION
## atf-report-gen - Update type definition version to allow 'vef' to be processed

Bumped types definition package to latest to include vef, work completed is one of the task elements (CB2-13597) of CB2-13178 to allow end of day reports to be created for vefs.

[CB2-13178](https://dvsa.atlassian.net/browse/CB2-13178)

## Checklist

- [X] Branch is rebased against the latest develop
- [X] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
